### PR TITLE
Getting Error while installing Contentify 2.4/2.5

### DIFF
--- a/contentify/Controllers/InstallController.php
+++ b/contentify/Controllers/InstallController.php
@@ -128,6 +128,21 @@ class InstallController extends Controller
 
                 break;
             case 5:
+                $this->createDatabase();
+                $this->createUserRoles();
+
+                /*
+                 * Create the daemon user (with ID = 1)
+                 */
+                $user = Sentinel::register(array(
+                    'email'     => 'daemon@contentify.org',
+                    'username'  => 'Daemon',
+                    'password'  => Str::random(),
+                    'activated' => false,
+                ));
+
+                $this->createSeed();
+                
                 $title      = 'Create super-admin user';
                 $content    = '<p>Please fill in the details of your user account.</p>'.
                               '<div class="warning">'.Form::errors($errors).'</div>'.
@@ -174,21 +189,6 @@ class InstallController extends Controller
                     "username = $username".PHP_EOL.
                     "password = $password"
                 );
-
-                $this->createDatabase();
-                $this->createUserRoles();
-
-                /*
-                 * Create the daemon user (with ID = 1)
-                 */
-                $user = Sentinel::register(array(
-                    'email'     => 'daemon@contentify.org',
-                    'username'  => 'Daemon',
-                    'password'  => Str::random(),
-                    'activated' => false,
-                ));
-
-                $this->createSeed();
 
                 $title      = 'Database setup complete';
                 $content    = '<p>Database filled with initial seed.</p>';


### PR DESCRIPTION
Getting Error while installing Contentify 2.4
[https://github.com/Contentify/Contentify/issues/380](https://github.com/Contentify/Contentify/issues/380)

```contentify/Controllers/InstallController.php```
> this line is used to create and seed database Line 178
```php
                $this->createDatabase();
                $this->createUserRoles();

                /*
                 * Create the daemon user (with ID = 1)
                 */
                $user = Sentinel::register(array(
                    'email'     => 'daemon@contentify.org',
                    'username'  => 'Daemon',
                    'password'  => Str::random(),
                    'activated' => false,
                ));

                $this->createSeed();
```
just before Contentify installer creating ```database.ini``` file
```php
                File::put(storage_path(self::INI_FILE), 
                    '; Auto-generated file with database connection settings.'.PHP_EOL.
                    '; See config/database.php for more settings.'.PHP_EOL.PHP_EOL.
                    "host = $host".PHP_EOL.
                    "database = $database".PHP_EOL.
                    "username = $username".PHP_EOL.
                    "password = $password"
                );
```
when Contentify trying to create database variables are loaded with default value which is allready present in default ```database.ini``` file
> you need to refresh so that you can load new variables from ```database.ini```

 My change is i am using ```step 4``` to craete ```database.ini``` file only
and ```step 5``` for creating and seeding database