### PR TITLE
Dockerfile Update for php 7

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@ Dockerfile
 .git
 .gitignore
 .gitattributes
+docker-compose.yml
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
-FROM php:5-apache
+FROM php:7-apache
 
 COPY . /var/www/html/
 
 RUN apt-get update && \
-	apt-get install -y zlib1g-dev && \
-	docker-php-ext-install bcmath zip mysql pdo pdo_mysql tokenizer
+	apt-get install -y zlib1g-dev libzip-dev libpng-dev libjpeg-dev libjpeg62-turbo-dev libgd-dev libfreetype6-dev && \
+	docker-php-ext-install bcmath zip mysqli pdo pdo_mysql tokenizer && \
+	docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
+	docker-php-ext-install -j$(nproc) gd && \
+	a2enmode rewrite
 
+RUN chown -R www-data:www-data /var/www/html/ && \
+	chmod -R 777 storage bootstrap/cache public && \
+	sed -i 's/\/var\/www\/html/\/var\/www\/html\/public/' /etc/apache2/sites-available/000-default.conf
 WORKDIR /var/www/html/
-
-RUN php composer.phar install && \
-	a2enmod rewrite && \
-	chmod -R 777 storage bootstrap/cache public
+USER www-data
+RUN php composer.phar install
+USER root


### PR DESCRIPTION
* Updated Dockerfile to php7-latest (currently php 7.3) as php >=7 is required
* added/modified necessary php modules for mysql and captcha
* made apache own all files and set the default webroot to the public folder
* composer is now running as apache so that all files are owned by apache