### PR TITLE
game icon size, awarded team

### DIFF
--- a/app/Modules/Awards/Http/Controllers/AwardsController.php
+++ b/app/Modules/Awards/Http/Controllers/AwardsController.php
@@ -22,7 +22,8 @@ class AwardsController extends FrontController
             'buttons'       => null,
             'brightenFirst' => false,
             'tableHead'     => [
-                trans('app.position')           => 'position', 
+                trans('app.position')           => 'position',
+                trans('app.object_team')        => 'team',                
                 trans('app.title')              => 'title', 
                 trans('app.object_tournament')  => 'tournament_id',
                 trans('app.object_game')        => 'game_id',
@@ -35,11 +36,12 @@ class AwardsController extends FrontController
                     $game = HTML::image(
                         $award->game->uploadPath().$award->game->icon, 
                         e($award->game->title), // "alt" attribute
-                        ['title' => e($award->game->title)]); // "title" attribute
+                        ['title' => e($award->game->title), 'width' => 16, 'height' => 16]); // "title" and "size" attributes
                 }
 
                 return [
                     raw($award->positionIcon()),
+                    raw($award->team->title),
                     raw($award->url ? HTML::link($award->url, e($award->title)) : e($award->title)),
                     $award->tournament ? $award->tournament->short : null,
                     raw($game),

--- a/app/Modules/Awards/Http/Controllers/AwardsController.php
+++ b/app/Modules/Awards/Http/Controllers/AwardsController.php
@@ -41,7 +41,7 @@ class AwardsController extends FrontController
 
                 return [
                     raw($award->positionIcon()),
-                    raw($award->team->title),
+                    $award->team ? $award->team->title : '',            
                     raw($award->url ? HTML::link($award->url, e($award->title)) : e($award->title)),
                     $award->tournament ? $award->tournament->short : null,
                     raw($game),


### PR DESCRIPTION
Set game size to 16x16. 
In case the uploaded game "icon" is bigger and perhaps used as a bigger version other places

Added the team that got the award to the table.