### PR TITLE
To not allow for "User Account Enumeration"

### DIFF
--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -14,9 +14,9 @@ return [
     */
 
     'password' => 'Passwords must be at least six characters and match the confirmation.',
-    'reset' => 'Your password has been reset!',
+    'reset' => 'If a matching account was found an email was sent to the email provided with a password reset link.',
     'sent' => 'We have e-mailed your password reset link!',
     'token' => 'This password reset token is invalid.',
-    'user' => "We can't find a user with that e-mail address.",
+    'user' => "If a matching account was found an email was sent to the email provided with a password reset link.",
 
 ];


### PR DESCRIPTION
We reply with the same message when the password reset link is it's successfully sent or if it's not.

(Should it be a , after found or not?)

Thoughts?