### PR TITLE
Http reverse proxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,18 @@ php:
 install:
 - php composer.phar update --no-suggest
 - php composer.phar install --no-suggest
+before_deploy:
+- zip -r release.zip ./*
 before_script:
 - if find . -name "*.php" ! -path "./vendor/*" -print0 | xargs -0 -n 1 -P 8 php -l
   | grep -v "No syntax errors detected"; then exit 1; fi
-script: 
+script:
+- ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=/vendor/*,/app/Modules/*/Resources/Views/*.php,_ide_helper.php,/database/*/*.php,/resources/views/*.php,/resources/views/*/*.php --standard=PSR2 --exclude=PSR2.Files.EndFileNewline,Squiz.Functions.MultiLineFunctionDeclaration,Squiz.WhiteSpace.SuperfluousWhitespace,Squiz.Functions.FunctionDeclaration,PSR2.Methods.FunctionClosingBrace -n --encoding=utf-8 --extensions=php ./* 
 deploy:
   provider: releases
   api_key:
     secure: PpIHZtADb9SWSWplTDJyUr7BqlwEJ0xphKsY+qK8y5RVtIQwoyu+UMaldXz+m4C7J7CSA/y4KPjyudo2y8kas6FhybNlSCu5iUwRXw6nupAyfomJfP63tvC6UCN6rAtWPtmH201FhPB+LaWtpRKx4gh/VK46hD0qIMADj1fKY2A=
-  file_glob: true
-  file: **
+  file: release.zip
   skip_cleanup: true
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,21 @@
 dist: xenial
 language: php
 php:
-  - '7.0'
-  - '7.3'
-  
+- '7.0'
+- '7.3'
 install:
-  - php composer.phar update --no-suggest
-  - php composer.phar install --no-suggest
-  
+- php composer.phar update --no-suggest
+- php composer.phar install --no-suggest
 before_script:
-  - if find . -name "*.php" ! -path "./vendor/*" -print0 | xargs -0 -n 1 -P 8 php -l | grep -v "No syntax errors detected"; then exit 1; fi
-
-script:
-#  - ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=/vendor/*,/app/Modules/*/Resources/Views/*.php,_ide_helper.php --standard=PSR2 --exclude=PSR2.Files.EndFileNewline,Squiz.Functions.MultiLineFunctionDeclaration,Squiz.WhiteSpace.SuperfluousWhitespace,Squiz.Functions.FunctionDeclaration,PSR2.Methods.FunctionClosingBrace -n --encoding=utf-8 --extensions=php ./*
+- if find . -name "*.php" ! -path "./vendor/*" -print0 | xargs -0 -n 1 -P 8 php -l
+  | grep -v "No syntax errors detected"; then exit 1; fi
+script: 
+deploy:
+  provider: releases
+  api_key:
+    secure: PpIHZtADb9SWSWplTDJyUr7BqlwEJ0xphKsY+qK8y5RVtIQwoyu+UMaldXz+m4C7J7CSA/y4KPjyudo2y8kas6FhybNlSCu5iUwRXw6nupAyfomJfP63tvC6UCN6rAtWPtmH201FhPB+LaWtpRKx4gh/VK46hD0qIMADj1fKY2A=
+  file_glob: true
+  file: **
+  skip_cleanup: true
+  on:
+    tags: true

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -17,6 +17,20 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+	/*
+        |--------------------------------------------------------------------------
+        | HTTPS Reverse Proxy Support
+        |--------------------------------------------------------------------------
+        |
+	| This is used to force https traffic when the application is behind
+        | a https reverse proxy
+        |
+        */
+        if(Config::get('app.https_reverse_proxy'))
+        {
+            \URL::forceScheme('https');
+        }
+
         /*
         |--------------------------------------------------------------------------
         | Custom Validation Rules

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -22,7 +22,7 @@ class AppServiceProvider extends ServiceProvider
         | HTTPS Reverse Proxy Support
         |--------------------------------------------------------------------------
         |
-	| This is used to force https traffic when the application is behind
+        | This is used to force https traffic when the application is behind
         | a https reverse proxy
         |
         */

--- a/config/app.php
+++ b/config/app.php
@@ -66,6 +66,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | HTTPS Reverse Proxy Support
+    |--------------------------------------------------------------------------
+    |
+    | This is used in special deployment scenarios in which the application
+    | is behind a https reverse proxy (typicaly in a docker/swarm environment)
+    | in order to present all links as https to the client as https
+    |
+    */
+
+    'https_reverse_proxy' => env('APP_HTTPS_REVERSE_PROXY', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Pagination Settings
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Checklist:

✓ I (at least tried to) stick to the PSR code style guide
✓ I have chosen the current development branch as the target
✓ I will add a link to the related issue (if there is one)

This PR add support for when Contentify is run with docker behind a https reverse proxy such as https://github.com/jwilder/nginx-proxy with the certificates being provided by Lets Encrypt via https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion

a typical user will not need https forced on, but in a reverse proxy scenario, the application server doesnt have the ssl certificate, the reverse proxy has the certificate.

without this, all sorts of fun issues occur during install, to where form validation doesnt work correctly, and most browsers warn about 'Mixed Content' https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content due to the application server attempting to return all links as http instead of https.

if behind a reverse proxy, the value in config/app.php can be set to true.
